### PR TITLE
fix: tunnel container commands

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,3 +16,4 @@ services:
     restart: always
     env_file:
       - ./environments/tunnel.env
+    command: tunnel run


### PR DESCRIPTION
## Description

#12 で `tunnel` container のコマンドを消したことにより動かなくなったため修正