### PR TITLE
ci: fix dependabot target directory for terraform packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,11 @@
 version: 2
 updates:
   - package-ecosystem: "terraform"
-    directory: "/"
+    directory: "/terraform"
     schedule:
       interval: "weekly"
       day: "saturday"
-      time: "09:00"
+      time: "03:00"
       timezone: "Asia/Tokyo"
     labels:
       - "Type: Dependencies"


### PR DESCRIPTION
## Description

- Change dependabot target directory for terraform packages.
- Change check schedule.

> [!NOTE]  
Upstream issue: dependabot/dependabot-core#649