### PR TITLE
chore(deps): bump container `cloudflare/cloudflared` to 2024.6.1

### DIFF
--- a/terraform/modules/aws-lightsail-container/main.tf
+++ b/terraform/modules/aws-lightsail-container/main.tf
@@ -48,7 +48,7 @@ resource "aws_lightsail_container_service_deployment_version" "gotosocial_contai
 
   container {
     container_name = "tunnel"
-    image          = "cloudflare/cloudflared:2024.6.0"
+    image          = "cloudflare/cloudflared:2024.6.1"
 
     command = ["tunnel", "run"]
 


### PR DESCRIPTION
Bump container  `cloudflare/cloudflared` to 2024.6.1.
Release Note: <https://github.com/cloudflare/cloudflared/releases/tag/2024.6.1>