### PR TITLE
chore(deps): bump container images

### DIFF
--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -1,7 +1,7 @@
-# This file is maintained automatically by "terraform init".
+# This file is maintained automatically by "tofu init".
 # Manual edits may be lost in future updates.
 
-provider "registry.terraform.io/cloudflare/cloudflare" {
+provider "registry.opentofu.org/cloudflare/cloudflare" {
   version     = "4.47.0"
   constraints = "~> 4.47.0"
   hashes = [
@@ -24,45 +24,38 @@ provider "registry.terraform.io/cloudflare/cloudflare" {
   ]
 }
 
-provider "registry.terraform.io/hashicorp/aws" {
+provider "registry.opentofu.org/hashicorp/aws" {
   version     = "5.78.0"
   constraints = "~> 5.78.0"
   hashes = [
-    "h1:OUmta/bL/0S6g4K/Mn1LBkEnMWNCq4dLsfYrdrllcEo=",
-    "zh:0ae7d41b96441d0cf7ce2e1337657bdb2e1e5c9f1c2227b0642e1dcec2f9dfba",
-    "zh:21f8f1edf477681ea3b095c02cad6b8e85262e45015de58e84e0c7b2bfe9a1f6",
-    "zh:2bdc335e341bf98445255549ae93d66cfb9bca706e62b949da98fe467c182cad",
-    "zh:2fe4096e260367a225a9faf4a424d62b87e5498f12cb43bdb6f4e713d11b82c3",
-    "zh:3c63bb7a7925d65118d17461f4691a22dbb55ea39a7404e4d71f6ccca8765f8b",
-    "zh:6609a28a1c638a1901d8007b5386868ccfd313b4df2e98b35d9fdef436974e3b",
-    "zh:7ae3aef43bc4b365824cca4659cf92459d766800656e354bdbf83feabab835e8",
-    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
-    "zh:c314efe454adc6ca483261c6906e64315aeb9db0c0332818714e9b81e07df0f0",
-    "zh:cd3e30396b554bbc1d260252db8a0f344065d619038fe60ea870689cd32c6aa9",
-    "zh:d1ba48fd9d8a1cb1daa927fb9e8bb708b857f2792d796e110460c6fdcd896a47",
-    "zh:d31c8abe75cb9cdc1c59ad9d356a1c3ae1ba8cd29ac15eb7e01b6cd01221ab04",
-    "zh:dc27c5c2116b4d9b404753f73bccaa635bce21f3bfb4bb7bc8e63225c36c98fe",
-    "zh:de491f0d05408378413187475c815d8cb2ac6bfa63d0b42a30ad5ee492e51c07",
-    "zh:eb44b45a40f80a309dd5b0eb7d7fcb2cbfe588fe2f18b173ef5851346898a662",
+    "h1:TDWBRFUaZq2MhMsXW20FCUgQvb1+Izu/fABfl3x1rdY=",
+    "zh:22f63d4f062b30ab6ca5f24d6217e948d6836415798a5cdb2819e6c89c9e17ae",
+    "zh:6f30507b9bf95a33be00ae8df72c37060f3fc37342d9eaf8647dccb7fc69cbce",
+    "zh:803239ae5e8b539d4845f4a79a119c58e9a584242432638596dfba5d1a92418c",
+    "zh:8520f6969b31b1a48c5ed42767ee7560b5b009d5d8eba7209d66383242d64ad9",
+    "zh:8f0c17c084f498fc91572672d533fb9e3cbcbd2ca6b082a1f86e5865fd7ff714",
+    "zh:9a2c59675d1d38bae227ed937895a7d0e41f797ea07f3c5645adec42bb7fb738",
+    "zh:b74410e55c54f288c84176e389eacfb1098aa4a738f761e1ef108c0f16623db4",
+    "zh:b7ac49d9c480cfe9531463a4cc197e76b8c4f8bb77a84088b15360c031b5ba05",
+    "zh:e7e9a5d7c27a1dd4971e9871588341864d200997d8b5159e0c4bfdbb41a4b339",
+    "zh:ec122979dcc9b0ba3e31b45bc8eaf7053e996d9379dc4e7c5698c336081f8ae7",
   ]
 }
 
-provider "registry.terraform.io/hashicorp/random" {
+provider "registry.opentofu.org/hashicorp/random" {
   version     = "3.6.3"
   constraints = "~> 3.6.0"
   hashes = [
-    "h1:Fnaec9vA8sZ8BXVlN3Xn9Jz3zghSETIKg7ch8oXhxno=",
-    "zh:04ceb65210251339f07cd4611885d242cd4d0c7306e86dda9785396807c00451",
-    "zh:448f56199f3e99ff75d5c0afacae867ee795e4dfda6cb5f8e3b2a72ec3583dd8",
-    "zh:4b4c11ccfba7319e901df2dac836b1ae8f12185e37249e8d870ee10bb87a13fe",
-    "zh:4fa45c44c0de582c2edb8a2e054f55124520c16a39b2dfc0355929063b6395b1",
-    "zh:588508280501a06259e023b0695f6a18149a3816d259655c424d068982cbdd36",
-    "zh:737c4d99a87d2a4d1ac0a54a73d2cb62974ccb2edbd234f333abd079a32ebc9e",
-    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
-    "zh:a357ab512e5ebc6d1fda1382503109766e21bbfdfaa9ccda43d313c122069b30",
-    "zh:c51bfb15e7d52cc1a2eaec2a903ac2aff15d162c172b1b4c17675190e8147615",
-    "zh:e0951ee6fa9df90433728b96381fb867e3db98f66f735e0c3e24f8f16903f0ad",
-    "zh:e3cdcb4e73740621dabd82ee6a37d6cfce7fee2a03d8074df65086760f5cf556",
-    "zh:eff58323099f1bd9a0bec7cb04f717e7f1b2774c7d612bf7581797e1622613a0",
+    "h1:Ry0Lr0zaoicslZlcUR4rAySPpl/a7QupfMfuAxhW3fw=",
+    "zh:1bfd2e54b4eee8c761a40b6d99d45880b3a71abc18a9a7a5319204da9c8363b2",
+    "zh:21a15ac74adb8ba499aab989a4248321b51946e5431219b56fc827e565776714",
+    "zh:221acfac3f7a5bcd6cb49f79a1fca99da7679bde01017334bad1f951a12d85ba",
+    "zh:3026fcdc0c1258e32ab519df878579160b1050b141d6f7883b39438244e08954",
+    "zh:50d07a7066ea46873b289548000229556908c3be746059969ab0d694e053ee4c",
+    "zh:54280cdac041f2c2986a585f62e102bc59ef412cad5f4ebf7387c2b3a357f6c0",
+    "zh:632adf40f1f63b0c5707182853c10ae23124c00869ffff05f310aef2ed26fcf3",
+    "zh:b8c2876cce9a38501d14880a47e59a5182ee98732ad7e576e9a9ce686a46d8f5",
+    "zh:f27e6995e1e9fe3914a2654791fc8d67cdce44f17bf06e614ead7dfd2b13d3ae",
+    "zh:f423f2b7e5c814799ad7580b5c8ae23359d8d342264902f821c357ff2b3c6d3d",
   ]
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -11,11 +11,10 @@ terraform {
     skip_s3_checksum            = true
     use_path_style              = true
 
-    # Replace secrets before exec terraform.
-    access_key = "<CLOUDFLARE_TERRAFORM_BACKEND_ACCESS_KEY>"
-    secret_key = "<CLOUDFLARE_TERRAFORM_BACKEND_ACCESS_SECRET>"
+    access_key = var.cloudflare_terraform_backend_access_key
+    secret_key = var.cloudflare_terraform_backend_access_secret
     endpoints = {
-      s3 = "https://<CLOUDFLARE_ACCOUNT_ID>.r2.cloudflarestorage.com"
+      s3 = "https://${var.cloudflare_account_id}.r2.cloudflarestorage.com"
     }
   }
 }

--- a/terraform/modules/aws-lightsail-container/main.tf
+++ b/terraform/modules/aws-lightsail-container/main.tf
@@ -48,7 +48,7 @@ resource "aws_lightsail_container_service_deployment_version" "gotosocial_contai
 
   container {
     container_name = "tunnel"
-    image          = "cloudflare/cloudflared:2025.2.0"
+    image          = "cloudflare/cloudflared:2025.2.1"
 
     command = ["tunnel", "run"]
 

--- a/terraform/modules/aws-lightsail-container/main.tf
+++ b/terraform/modules/aws-lightsail-container/main.tf
@@ -22,7 +22,7 @@ resource "aws_lightsail_container_service_deployment_version" "gotosocial_contai
 
   container {
     container_name = "app"
-    image          = "superseriousbusiness/gotosocial:0.17.4"
+    image          = "superseriousbusiness/gotosocial:0.18.2"
 
     environment = {
       SERVICE_CON                          = "service://localhost"

--- a/terraform/variable.tf
+++ b/terraform/variable.tf
@@ -1,6 +1,6 @@
 variable "cloudflare_api_token" {
   type        = string
-  description = "The API Token for opetarions to cloudflare."
+  description = "The API Token for operations to cloudflare."
 }
 
 variable "cloudflare_account_id" {
@@ -16,4 +16,14 @@ variable "cloudflare_zone_id" {
 variable "cloudflare_record_name" {
   type        = string
   description = "The name of the cloudflare DNS record."
+}
+
+variable "cloudflare_terraform_backend_access_key" {
+  type        = string
+  description = "The cloudflare r2 access key used to save tfstate in storage."
+}
+
+variable "cloudflare_terraform_backend_access_secret" {
+  type        = string
+  description = "The cloudflare r2 secret key used to save tfstate in storage."
 }


### PR DESCRIPTION
- Change terraform cli to `opentofu`.
- Bump container `cloudflare/cloudflared`to `2025.2.1`.
- Bump container `superseriousbusiness/gotosocial` to `0.18.2`.