### PR TITLE
chore(deps): bump container `superseriousbusiness/gotosocial` to `0.19.0`

### DIFF
--- a/terraform/modules/aws-lightsail-container/main.tf
+++ b/terraform/modules/aws-lightsail-container/main.tf
@@ -22,7 +22,7 @@ resource "aws_lightsail_container_service_deployment_version" "gotosocial_contai
 
   container {
     container_name = "app"
-    image          = "superseriousbusiness/gotosocial:0.18.3"
+    image          = "superseriousbusiness/gotosocial:0.19.0"
 
     environment = {
       SERVICE_CON                          = "service://localhost"


### PR DESCRIPTION
Bump container `superseriousbusiness/gotosocial` to `0.19.0`.
Release Note: <https://github.com/superseriousbusiness/gotosocial/releases/tag/v0.19.0>