### PR TITLE
chore: migrate deprecated reviewers option in dependabot configulation

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* RShirohara@proton.me

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,5 +11,3 @@ updates:
       - "Type: Dependencies"
     assignees:
       - "RShirohara"
-    reviewers:
-      - "RShirohara"


### PR DESCRIPTION
Move deprecated `reviewers` option in dependabot configuration
to a method using `/.github/CODEOWNERS` file.