### PR TITLE
chore(deps): bump container version

### DIFF
--- a/terraform/modules/aws-lightsail-container/main.tf
+++ b/terraform/modules/aws-lightsail-container/main.tf
@@ -48,7 +48,7 @@ resource "aws_lightsail_container_service_deployment_version" "gotosocial_contai
 
   container {
     container_name = "tunnel"
-    image          = "cloudflare/cloudflared:2025.6.0"
+    image          = "cloudflare/cloudflared:2025.6.1"
 
     command = ["tunnel", "run"]
 

--- a/terraform/modules/aws-lightsail-container/main.tf
+++ b/terraform/modules/aws-lightsail-container/main.tf
@@ -22,7 +22,7 @@ resource "aws_lightsail_container_service_deployment_version" "gotosocial_contai
 
   container {
     container_name = "app"
-    image          = "superseriousbusiness/gotosocial:0.19.0"
+    image          = "superseriousbusiness/gotosocial:0.19.1"
 
     environment = {
       SERVICE_CON                          = "service://localhost"


### PR DESCRIPTION
- Bump container `cloudflare/cloudflared` to [`2025.6.1`](https://github.com/cloudflare/cloudflared/releases/tag/2025.6.1).
- Bump container superseriousbusiness/gotosocial to [`0.19.1`](https://codeberg.org/superseriousbusiness/gotosocial/releases/tag/v0.19.1).